### PR TITLE
Support 'publish_test_container' as non-root user.

### DIFF
--- a/prodactivity/testrunners/tempest/project_docker.tmpl
+++ b/prodactivity/testrunners/tempest/project_docker.tmpl
@@ -52,8 +52,6 @@ RUN pip install -r neutron-lbaas/test-requirements.txt
 RUN git clone https://github.com/openstack/tempest.git
 RUN pip install ./tempest 
 
-
-
 RUN mkdir -p /etc/tempest
 COPY ./tempest/config-files/accounts.yaml /etc/tempest/
 COPY ./tempest/config-files/tempest.conf /etc/tempest/


### PR DESCRIPTION
Issues:
Fixes #13

Problem:  For prototyping we were assuming root access in the docker worker
this assumption is not met in nightly regression runs so we needed to upgrade
to enable the publish_docker_test_container to function without root
privileges.

Analysis: In particular the docker socker '/var/run/docker.sock' belongs
to group 'staff' so the user (e.g. buildbot) needs to also belong to that
group.'

Tests:  Running tests from the "driver" repo in a nightly regression proves
these changes.   The changes should also be tested manually before acceptance.